### PR TITLE
Bugfix for empty second drive to avoid grep error

### DIFF
--- a/minibolt.sh
+++ b/minibolt.sh
@@ -248,7 +248,7 @@ if [ -n "${ext_storage2nd}" ]; then
     storage2nd=$(printf "%s" "$(df -h|grep ${ext_storage2nd}|awk '{print $4}')") 2>/dev/null
 else
     storage2nd_free_ratio=0
-    storage2nd="none"
+    storage2nd=""
 fi
 
 if [ -z "${storage2nd}" ]; then

--- a/minibolt.sh
+++ b/minibolt.sh
@@ -243,8 +243,13 @@ else
   color_storage=${color_green}
 fi
 
-storage2nd_free_ratio=$(printf "%.0f" "$(df  | grep ${ext_storage2nd} | awk '{ print $4/$2*100 }')") 2>/dev/null
-storage2nd=$(printf "%s" "$(df -h|grep ${ext_storage2nd}|awk '{print $4}')") 2>/dev/null
+if [ -n "${ext_storage2nd}" ]; then
+    storage2nd_free_ratio=$(printf "%.0f" "$(df | grep ${ext_storage2nd} | awk '{ print $4/$2*100 }')") 2>/dev/null
+    storage2nd=$(printf "%s" "$(df -h|grep ${ext_storage2nd}|awk '{print $4}')") 2>/dev/null
+else
+    storage2nd_free_ratio=0
+    storage2nd="none"
+fi
 
 if [ -z "${storage2nd}" ]; then
   storage2nd="none"


### PR DESCRIPTION
Bugfix for not having a second drive to avoid a grep error for an empty result.

Logoutput of the error:
+++ awk '{ print $4/$2*100 }'
+++ df
+++ grep '/$'
++ printf %.0f 66.2928
+ storage_free_ratio=66
+++ awk '{print $4}'
+++ grep '/$'
+++ df -h
++ printf %s 464G
+ storage=464G
+ '[' 66 -lt 10 ']'
+ color_storage='\033[0;32m'
+++ awk '{ print $4/$2*100 }'
+++ grep
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
+++ df
++ printf %.0f ''
+ storage2nd_free_ratio=0
+++ awk '{print $4}'
+++ grep
+++ df -h
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
++ printf %s ''
+ storage2nd=
+ '[' -z '' ']'
+ storage2nd=none
+ color_storage2nd='\033[0;37m'
++ numfmt --to=iec
++ awk -v OFMT=%.0f '{sum+=$0} END{print sum}'
++ jq '.[] | [(select(.ifname!="lo") | .stats64.rx.bytes)//0] | add'
++ ip -j -s link show
+ network_rx=6.6G